### PR TITLE
Initializes api object

### DIFF
--- a/shared_resources/reddit_download_submissions_function-tiana_mako-20230510.ipynb
+++ b/shared_resources/reddit_download_submissions_function-tiana_mako-20230510.ipynb
@@ -30,7 +30,8 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "from pmaw import PushshiftAPI"
+    "from pmaw import PushshiftAPI\n",
+    "api = PushshiftAPI()"
    ]
   },
   {


### PR DESCRIPTION
The reference to `api` in `get_submissions()` is throwing an error because it was never initialized. This will fix the error by initializing the `PushShiftAPI` client in the `api` variable.